### PR TITLE
✨ AFK への出入り時にgreetingメッセージを読み上げるようにする

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-polly",
  "aws-types",
+ "futures",
  "html-escape",
  "hyper 1.5.2",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ mockall = "0.13.0"
 mockall_double = "0.3.0"
 serde = "1.0.217"
 sentry = { version = "0.35.0", features = ["tracing"] }
+futures = "0.3"
 
 [dependencies.reqwest]
 version = "0.11"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Welcome to `discord-tts-bot`! This innovative Discord bot uses text-to-speech (T
 - **High Precision Text-to-Speech:** Utilizes AWS Polly for high accuracy in reading both Kanji and English text, providing a natural voice experience across diverse language environments.
 - **Text-to-Speech in Voice Channels:** Simply type, and the bot speaks in your voice channel.
 - **Easy to Set Up:** A few steps and your bot is ready on your server.
+- **Smart Voice Channel Interactions:** 
+  - Welcomes users with "いらっしゃい" when they join
+  - Says "いってらっしゃい" when users leave
+  - Says "おやすみなさい" when users move to AFK channel
+  - Says "おはようございます" when users return from AFK channel
+  - All messages include the user's nickname or username for a personalized experience
 
 ## Getting Started
 

--- a/src/commands/usecase/services/play/service.rs
+++ b/src/commands/usecase/services/play/service.rs
@@ -1,7 +1,7 @@
 use serenity::{client::Context, model};
 
 use crate::constants;
-use crate::HttpKey;
+use crate::model::HttpKey;
 
 use super::Error;
 use super::TrackTiming;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,9 @@
+use sentry;
+
+pub fn report_error(message: &str) {
+    sentry::capture_message(message, sentry::Level::Error);
+}
+
+pub fn format_err<T: std::fmt::Debug>(context: &str, err: T) -> String {
+    format!("{}: {:?}", context, err)
+}

--- a/src/handler/error.rs
+++ b/src/handler/error.rs
@@ -1,0 +1,7 @@
+pub fn report_error(message: &str) {
+    sentry::capture_message(message, sentry::Level::Error);
+}
+
+pub fn format_err<T: std::fmt::Debug>(context: &str, err: T) -> String {
+    format!("{}: {:?}", context, err)
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -20,7 +20,11 @@ use model::{
     voice::Voice,
 };
 pub mod usecase;
-use usecase::set_help_message_to_activity::set_help_message_to_activity;
+use usecase::{
+    interface::Speaker,
+    set_help_message_to_activity::set_help_message_to_activity,
+    text_to_speech::SpeechMessage,
+};
 
 #[cfg(feature = "tts")]
 use usecase::{speech_welcome_see_you::speech_greeting, text_to_speech::text_to_speech};
@@ -131,21 +135,41 @@ impl EventHandler for Handler {
         old_voice_state: Option<voice::VoiceState>,
         new_voice_state: voice::VoiceState,
     ) {
-        let state = CurrentVoiceState::new(new_voice_state);
-        let change = state.change_of_states(old_voice_state.as_ref());
-        let member = state.voice_member().await.expect("member is not received");
-        let voice = Voice::from(&ctx, member.guild_id).await;
-        let role = member.role(&ctx).await;
+        let state = CurrentVoiceState::new(new_voice_state.clone());
+        let change = state.change_of_states(old_voice_state.as_ref(), &ctx);
+        let member = match state.voice_member().await {
+            Ok(m) => m,
+            Err(e) => {
+                println!("Error getting member: {:?}", e);
+                return;
+            }
+        };
+        let guild_id = member.guild_id;
+        let voice = Voice::from(&ctx, guild_id).await;
+        let role = match member.role(&ctx).await {
+            Ok(r) => r,
+            Err(e) => {
+                println!("Error getting role: {:?}", e);
+                return;
+            }
+        };
+
         if let Role::Me = role {
             if let ChangeOfStates::Leave = change {
-                voice.remove().await.unwrap();
+                if let Err(e) = voice.remove().await {
+                    println!("Error removing voice: {:?}", e);
+                }
                 println!("removed");
             };
             return println!("This is me(bot). My entering is ignored.");
         }
+
+        println!("old_voice_state: {:?}", old_voice_state);
+        println!("new_voice_state: {:?}", new_voice_state);
+
         #[cfg(feature = "tts")]
-        speech_greeting(&ctx, &voice, &change, &member.user).await;
-        leave_if_alone(&ctx, &voice).await;
+        let _ = speech_greeting(&ctx, &voice, &change, &member.user).await;
+        let _ = leave_if_alone(&ctx, &voice).await;
     }
 }
 
@@ -158,5 +182,79 @@ async fn leave_if_alone(ctx: &Context, voice: &Voice) {
             Error::ConnectionNotFound => (),
             Error::NotInVoiceChannel => (),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockall::predicate::*;
+    use mockall::mock;
+
+    mock! {
+        pub Voice {
+            async fn speech(&self, msg: SpeechMessage);
+        }
+    }
+
+    #[test]
+    fn test_afk_detection() {
+        // 通常状態からAFKに変更されるケース
+        let old_deaf = false;
+        let new_deaf = true;
+        assert!(
+            !old_deaf && new_deaf,
+            "通常状態からAFKへの変更を検知できません"
+        );
+
+        // AFKから通常状態に戻るケース
+        let old_deaf = true;
+        let new_deaf = false;
+        assert!(
+            old_deaf && !new_deaf,
+            "AFKから通常状態への変更を検知できません"
+        );
+
+        // 最初からAFKの状態のケース
+        let old_deaf = true;
+        let new_deaf = true;
+        assert!(
+            !(!old_deaf && new_deaf),
+            "既にAFKの状態で誤検知しています"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_speech_messages() {
+        let mut mock_voice = MockVoice::new();
+
+        // おやすみなさいのテスト
+        mock_voice
+            .expect_speech()
+            .with(eq(SpeechMessage {
+                value: "おやすみなさい".to_string(),
+            }))
+            .times(1)
+            .return_once(|_| ());
+
+        // おはようございますのテスト
+        mock_voice
+            .expect_speech()
+            .with(eq(SpeechMessage {
+                value: "おはようございます".to_string(),
+            }))
+            .times(1)
+            .return_once(|_| ());
+
+        // メッセージの内容を確認
+        let goodnight_msg = SpeechMessage {
+            value: "おやすみなさい".to_string(),
+        };
+        mock_voice.speech(goodnight_msg).await;
+
+        let morning_msg = SpeechMessage {
+            value: "おはようございます".to_string(),
+        };
+        mock_voice.speech(morning_msg).await;
     }
 }

--- a/src/handler/model/speaker.rs
+++ b/src/handler/model/speaker.rs
@@ -49,11 +49,14 @@ impl CurrentVoiceState {
             Some(prev_state) => {
                 if self.state.channel_id.is_none() {
                     ChangeOfStates::Leave
-                } else if let (Some(prev_channel), Some(curr_channel)) = (prev_state.channel_id, self.state.channel_id) {
+                } else if let (Some(prev_channel), Some(curr_channel)) =
+                    (prev_state.channel_id, self.state.channel_id)
+                {
                     if prev_channel == curr_channel {
                         ChangeOfStates::Stay
                     } else if let Some(guild_id) = self.state.guild_id {
-                        let afk_channel_id = ctx.cache
+                        let afk_channel_id = ctx
+                            .cache
                             .guild(guild_id)
                             .and_then(|g| g.afk_metadata.clone())
                             .map(|m| m.afk_channel_id);
@@ -61,7 +64,9 @@ impl CurrentVoiceState {
                         if let Some(afk_channel_id) = afk_channel_id {
                             if prev_channel != afk_channel_id && curr_channel == afk_channel_id {
                                 ChangeOfStates::EnterAFK
-                            } else if prev_channel == afk_channel_id && curr_channel != afk_channel_id {
+                            } else if prev_channel == afk_channel_id
+                                && curr_channel != afk_channel_id
+                            {
                                 ChangeOfStates::LeaveAFK
                             } else {
                                 ChangeOfStates::Stay

--- a/src/handler/model/speaker.rs
+++ b/src/handler/model/speaker.rs
@@ -15,12 +15,12 @@ pub struct VoiceMember {
 }
 
 impl VoiceMember {
-    pub async fn role(&self, ctx: &Context) -> Role {
+    pub async fn role(&self, ctx: &Context) -> Result<Role, String> {
         let current_user_id = ctx.cache.current_user().id;
         if current_user_id == self.user.id {
-            return Role::Me;
+            return Ok(Role::Me);
         }
-        Role::Other
+        Ok(Role::Other)
     }
 }
 
@@ -43,12 +43,35 @@ impl CurrentVoiceState {
     pub fn change_of_states(
         &self,
         previous_voice_state: Option<&voice::VoiceState>,
+        ctx: &Context,
     ) -> ChangeOfStates {
         match previous_voice_state {
-            // 他サーバーに反応しないように
-            Some(_) => {
+            Some(prev_state) => {
                 if self.state.channel_id.is_none() {
                     ChangeOfStates::Leave
+                } else if let (Some(prev_channel), Some(curr_channel)) = (prev_state.channel_id, self.state.channel_id) {
+                    if prev_channel == curr_channel {
+                        ChangeOfStates::Stay
+                    } else if let Some(guild_id) = self.state.guild_id {
+                        let afk_channel_id = ctx.cache
+                            .guild(guild_id)
+                            .and_then(|g| g.afk_metadata.clone())
+                            .map(|m| m.afk_channel_id);
+
+                        if let Some(afk_channel_id) = afk_channel_id {
+                            if prev_channel != afk_channel_id && curr_channel == afk_channel_id {
+                                ChangeOfStates::EnterAFK
+                            } else if prev_channel == afk_channel_id && curr_channel != afk_channel_id {
+                                ChangeOfStates::LeaveAFK
+                            } else {
+                                ChangeOfStates::Stay
+                            }
+                        } else {
+                            ChangeOfStates::Stay
+                        }
+                    } else {
+                        ChangeOfStates::Stay
+                    }
                 } else {
                     ChangeOfStates::Stay
                 }
@@ -62,6 +85,8 @@ pub enum ChangeOfStates {
     Join,
     Leave,
     Stay,
+    EnterAFK,
+    LeaveAFK,
 }
 
 pub enum Role {

--- a/src/handler/model/voice/mod.rs
+++ b/src/handler/model/voice/mod.rs
@@ -7,26 +7,44 @@ pub use crate::model::Voice;
 use polly::types::VoiceId;
 use serenity::async_trait;
 use songbird::input::Input;
-use tracing;
 
 #[async_trait]
 #[cfg_attr(feature = "mock", mockall::automock)]
 impl Speaker for Voice {
     #[cfg(feature = "aws")]
-    async fn speech(&self, msg: SpeechMessage) {
+    async fn speech(&self, msg: SpeechMessage) -> Result<(), String> {
         if let Ok(handler) = self.handler().await {
             let file_path = SpeechFilePath::new(SoundPath::new(GuildPath::new(&self.guild_id)));
             let speech_file =
                 match generate_speech_file(&msg.value, VoiceId::Mizuki, &file_path, false).await {
                     Ok(file) => file,
                     Err(e) => {
-                        tracing::error!("Failed to generate speech file: {:?}", e);
-                        return;
+                        let err = format!("Failed to generate speech file: {:?}", e);
+                        sentry::capture_message(&err, sentry::Level::Error);
+                        return Err(err);
                     }
                 };
-            let input = get_input_from_local(speech_file).await;
-            println!("play_input: {:?}", msg.value);
-            play_input(&handler, input).await;
+
+            match get_input_from_local(speech_file).await {
+                Ok(input) => {
+                    println!("play_input: {:?}", msg.value);
+                    if let Err(e) = play_input(&handler, input).await {
+                        let err = format!("Failed to play input: {:?}", e);
+                        sentry::capture_message(&err, sentry::Level::Error);
+                        return Err(err);
+                    }
+                    Ok(())
+                }
+                Err(e) => {
+                    let err = format!("Failed to get input from local: {:?}", e);
+                    sentry::capture_message(&err, sentry::Level::Error);
+                    Err(err)
+                }
+            }
+        } else {
+            let err = "Failed to get voice handler".to_string();
+            sentry::capture_message(&err, sentry::Level::Error);
+            Err(err)
         }
     }
     fn guild_id(&self) -> serenity::model::id::GuildId {
@@ -34,24 +52,26 @@ impl Speaker for Voice {
     }
 }
 
-async fn get_input_from_local(file_path: String) -> Input {
+async fn get_input_from_local(file_path: String) -> Result<Input, std::io::Error> {
     use songbird::input::codecs::{CODEC_REGISTRY, PROBE};
-    let in_memory = tokio::fs::read(file_path).await.unwrap();
+    let in_memory = tokio::fs::read(file_path).await?;
     let in_memory_input: songbird::input::Input = songbird::input::Input::from(in_memory);
     in_memory_input
         .make_playable_async(&CODEC_REGISTRY, &PROBE)
         .await
-        .unwrap()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
 }
 
 async fn play_input(
     handler_lock: &std::sync::Arc<serenity::prelude::Mutex<songbird::Call>>,
     input: Input,
-) {
+) -> Result<(), String> {
     let mut handler = handler_lock.lock().await;
-
     let audio = handler.enqueue_input(input).await;
-    audio.set_volume(constants::volume::VOICE).unwrap();
+    audio
+        .set_volume(constants::volume::VOICE)
+        .map_err(|e| format!("Failed to set volume: {:?}", e))?;
+    Ok(())
 }
 
 // #[cfg(test)]

--- a/src/handler/model/voice/mod.rs
+++ b/src/handler/model/voice/mod.rs
@@ -25,6 +25,7 @@ impl Speaker for Voice {
                     }
                 };
             let input = get_input_from_local(speech_file).await;
+            println!("play_input: {:?}", msg.value);
             play_input(&handler, input).await;
         }
     }

--- a/src/handler/usecase/interface.rs
+++ b/src/handler/usecase/interface.rs
@@ -5,7 +5,7 @@ use serenity::async_trait;
 #[async_trait]
 pub trait Speaker {
     #[cfg(feature = "aws")]
-    async fn speech(&self, msg: SpeechMessage);
+    async fn speech(&self, msg: SpeechMessage) -> Result<(), String>;
     fn guild_id(&self) -> serenity::model::id::GuildId;
 }
 

--- a/src/handler/usecase/interface.rs
+++ b/src/handler/usecase/interface.rs
@@ -1,12 +1,13 @@
+#[cfg(feature = "tts")]
 use super::text_to_speech::SpeechMessage;
-use serenity::async_trait;
+use serenity::{async_trait, model::id::GuildId};
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait Speaker {
-    #[cfg(feature = "aws")]
+    #[cfg(feature = "tts")]
     async fn speech(&self, msg: SpeechMessage) -> Result<(), String>;
-    fn guild_id(&self) -> serenity::model::id::GuildId;
+    fn guild_id(&self) -> GuildId;
 }
 
 #[cfg_attr(test, mockall::automock)]

--- a/src/handler/usecase/speech_welcome_see_you.rs
+++ b/src/handler/usecase/speech_welcome_see_you.rs
@@ -7,14 +7,20 @@ use serenity::model::prelude::User;
 use serenity::client::Context;
 
 #[cfg(feature = "tts")]
-pub async fn speech_greeting(ctx: &Context, voice: &Voice, change: &ChangeOfStates, user: &User) {
+pub async fn speech_greeting(
+    ctx: &Context,
+    voice: &Voice,
+    change: &ChangeOfStates,
+    user: &User,
+) -> Result<(), String> {
     let name = match user.nick_in(ctx, voice.guild_id()).await {
         Some(n) => n,
         None => user.name.clone(),
     };
     if let Some(message) = greeting_word(change, &name) {
-        voice.speech(message).await
+        voice.speech(message).await?;
     }
+    Ok(())
 }
 
 #[cfg(feature = "tts")]

--- a/src/handler/usecase/speech_welcome_see_you.rs
+++ b/src/handler/usecase/speech_welcome_see_you.rs
@@ -23,6 +23,8 @@ fn greeting_word(change_of_states: &ChangeOfStates, name: &str) -> Option<Speech
         ChangeOfStates::Stay => None,
         ChangeOfStates::Leave => Some("いってらっしゃい"),
         ChangeOfStates::Join => Some("いらっしゃい"),
+        ChangeOfStates::EnterAFK => Some("おやすみなさい"),
+        ChangeOfStates::LeaveAFK => Some("おはようございます"),
     }
     .map(|message_prefix| SpeechMessage {
         value: format!("{name}さん{message_prefix}"),

--- a/src/handler/usecase/text_to_speech/text_to_speech_base.rs
+++ b/src/handler/usecase/text_to_speech/text_to_speech_base.rs
@@ -5,6 +5,8 @@ use super::config;
 #[cfg(feature = "tts")]
 use super::text_to_speech_message::Message;
 #[cfg(feature = "tts")]
+use crate::handler::error::{format_err, report_error};
+#[cfg(feature = "tts")]
 use crate::infrastructure::GuildPath;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -28,10 +30,7 @@ pub async fn text_to_speech(speaker: Box<dyn Speaker + Sync + Send>, msg: Messag
         return;
     }
     if let Err(e) = speaker.speech(msg.to_speech_message(speech_options)).await {
-        sentry::capture_message(
-            &format!("Failed to speech message: {:?}", e),
-            sentry::Level::Error,
-        );
+        report_error(&format_err("Failed to speech message", e));
     }
 }
 
@@ -47,9 +46,8 @@ fn is_ignore_channel(read_channel_id: Option<u64>, msg: &Message) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(test)]
-    use super::super::super::interface::MockSpeaker;
     use super::*;
+    use crate::handler::usecase::interface::MockSpeaker;
     use regex::Regex;
     use serenity::model::{channel::Message as SerenityMessage, id::GuildId};
 

--- a/src/infrastructure/aws/tts.rs
+++ b/src/infrastructure/aws/tts.rs
@@ -12,14 +12,23 @@ use super::SpeechFilePath;
 /// ## Examples
 ///
 /// ```no_run
+/// use polly::types::VoiceId;
+/// use std::path::{Path, PathBuf};
+/// use discord_tts_bot::infrastructure::tts::generate_speech_file;
+/// use discord_tts_bot::infrastructure::SpeechFilePath;
+///
+/// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+/// let path = PathBuf::from("sample");
+/// let file_path = SpeechFilePath::from(path);
 /// let result = generate_speech_file(
-///   String::from("おはようございます"),
-///   VoiceId::Mizuki,
-///   "sample",
-///   true,
-/// )
-/// .await;
-/// Path::new(result.unwrap()).exists(); // true or false
+///     "おはようございます",
+///     VoiceId::Mizuki,
+///     &file_path,
+///     true,
+/// ).await?;
+/// assert!(Path::new(&result).exists());
+/// # Ok(())
+/// # }
 /// ```
 pub async fn generate_speech_file(
     content: &str,

--- a/src/infrastructure/path_router/shared_sound.rs
+++ b/src/infrastructure/path_router/shared_sound.rs
@@ -2,6 +2,12 @@ pub struct Path {
     value: std::path::PathBuf,
 }
 
+impl Default for Path {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Path {
     pub fn new() -> Self {
         let value: std::path::PathBuf = super::root_path().join("sounds");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod commands;
+pub mod constants;
+pub mod error;
+pub mod handler;
+pub mod infrastructure;
+pub mod model;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,25 +2,16 @@ use std::env;
 
 use reqwest::Client as HttpClient;
 use serenity::{client::Client, prelude::GatewayIntents};
-use songbird::typemap::TypeMapKey;
-
 use songbird::SerenityInit;
 
-mod handler;
-use handler::Handler;
-
-mod infrastructure;
+use discord_tts_bot::handler::Handler;
+use discord_tts_bot::model::HttpKey;
 
 mod commands;
-
-mod model;
-
 mod constants;
-
-pub struct HttpKey;
-impl TypeMapKey for HttpKey {
-    type Value = HttpClient;
-}
+mod handler;
+mod infrastructure;
+mod model;
 
 #[tokio::main]
 async fn main() {

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,5 +1,15 @@
+use reqwest::Client;
+use serenity::prelude::TypeMapKey;
+
+pub mod message;
 pub mod voice;
-pub use voice::Voice;
-mod message;
+
 #[cfg(feature = "tts")]
 pub use message::Message;
+pub use voice::Voice;
+
+pub struct HttpKey;
+
+impl TypeMapKey for HttpKey {
+    type Value = Client;
+}


### PR DESCRIPTION
* resolve https://github.com/tktcorporation/discord-tts-bot/issues/35

- **:sparkles: AFK への出入り時にgreetingメッセージを読み上げるようにする**
- **:dizzy: エラーハンドリングの強化**
- **:dizzy: エラーレポートの関数をまとめる**
