### PR TITLE
493/feature/select channel

### DIFF
--- a/src/commands/usecase/slash_commands/select_channel.rs
+++ b/src/commands/usecase/slash_commands/select_channel.rs
@@ -12,14 +12,14 @@ pub struct SelectChannel {}
 impl SlashCommand for SelectChannel {
     async fn run(_ctx: &Context, command: &CommandInteraction) -> SlashCommandResult {
         let resolved_options = command.data.options();
-        let channel = match resolved_options.first().unwrap() {
-            ResolvedOption {
+        let channel_id = match resolved_options.first() {
+            Some(ResolvedOption {
                 value: ResolvedValue::Channel(channel),
                 ..
-            } => channel,
-            _ => return SlashCommandResult::Simple(Some("Must provide a channel".to_string())),
+            }) => channel.id,
+            None => command.channel_id,
+            _ => return SlashCommandResult::Simple(Some("Invalid channel provided".to_string())),
         };
-        let channel_id = channel.id;
 
         let guild_id = command.guild_id.unwrap();
         services::select_channel(&guild_id, channel_id).await;
@@ -33,9 +33,9 @@ impl SlashCommand for SelectChannel {
                 CreateCommandOption::new(
                     CommandOptionType::Channel,
                     "channel",
-                    "channel to speech",
+                    "channel to speech (defaults to current channel if not specified)",
                 )
-                .required(true),
+                .required(false),
             )
     }
 }

--- a/src/commands/usecase/slash_commands/select_channel.rs
+++ b/src/commands/usecase/slash_commands/select_channel.rs
@@ -28,7 +28,7 @@ impl SlashCommand for SelectChannel {
 
     fn register(command: CreateCommand) -> CreateCommand {
         command
-            .description("select a channel to speech")
+            .description("select a channel to speech (optional)")
             .add_option(
                 CreateCommandOption::new(
                     CommandOptionType::Channel,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,13 @@
 use sentry;
+use std::error::Error;
 
 pub fn report_error(message: &str) {
     sentry::capture_message(message, sentry::Level::Error);
+}
+
+pub fn report_error_with_cause<E: Error + ?Sized>(message: &str, error: &E) {
+    sentry::capture_error(error);
+    sentry::capture_message(&format!("{}: {}", message, error), sentry::Level::Error);
 }
 
 pub fn format_err<T: std::fmt::Debug>(context: &str, err: T) -> String {

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -106,6 +106,7 @@ impl EventHandler for Handler {
             }
         });
 
+        // 新しいコマンドを登録
         Command::set_global_commands(&ctx.http, SlashCommands::get_commands())
             .await
             .expect("Failed to set global commands");

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ async fn main() {
     let _guard = sentry::init(sentry::ClientOptions {
         dsn: env::var("SENTRY_DSN").ok().and_then(|dsn| dsn.parse().ok()),
         release: sentry::release_name!(),
-        traces_sample_rate: 1.0,
+        auto_session_tracking: true,
+        debug: true,
         ..Default::default()
     });
 


### PR DESCRIPTION
This pull request includes several changes to improve error handling, command registration, and the main function configuration in the project. The most important changes include improvements to the `SelectChannel` command, enhancements to error reporting, and adjustments to the Sentry configuration.

Improvements to `SelectChannel` command:

* [`src/commands/usecase/slash_commands/select_channel.rs`](diffhunk://#diff-0a81ad0a190892efee49d67e62acf66b30b2c65bfd17405172611929a4f8c577L15-L22): Modified the `run` method to handle cases where no channel is provided, defaulting to the current channel, and updated the command description and option to reflect that the channel is optional. [[1]](diffhunk://#diff-0a81ad0a190892efee49d67e62acf66b30b2c65bfd17405172611929a4f8c577L15-L22) [[2]](diffhunk://#diff-0a81ad0a190892efee49d67e62acf66b30b2c65bfd17405172611929a4f8c577L31-R38)

Enhancements to error reporting:

* [`src/error.rs`](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR2-R12): Added a new function `report_error_with_cause` to capture errors with their causes using Sentry, improving error diagnostics.

Adjustments to Sentry configuration:

* [`src/main.rs`](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL21-R22): Enabled `auto_session_tracking` and `debug` options in the Sentry initialization for better monitoring and debugging.

Additional command registration:

* [`src/handler/mod.rs`](diffhunk://#diff-99620cff6123acf0598ed2ec9d1c06f02cb0ddece1bef898047eb303d0b71fc2R109): Added a comment to indicate the registration of new commands in the event handler.