### PR TITLE
文字数が長い場合でもspoilerが適切に処理されるように修正

### DIFF
--- a/src/handler/usecase/text_to_speech/text_to_speech_message.rs
+++ b/src/handler/usecase/text_to_speech/text_to_speech_message.rs
@@ -159,12 +159,14 @@ mod tests {
     mod convert_discord_string_test {
         use super::*;
 
+        /// メンション文字列が正しく除去されるかテストします。
         #[test]
         fn test_remove_mention_string() {
             let str = "aaa<@8379454856049>eeee";
             let result = convert_discord_string(str);
             assert_eq!("aaaeeee", result);
         }
+        /// 複数のメンション文字列が正しく除去されるかテストします。
         #[test]
         fn test_remove_double_mention_string() {
             let str = "aaa<@8379454856049>eeee<@8379454856049>uuu";
@@ -172,12 +174,14 @@ mod tests {
             assert_eq!("aaaeeeeuuu", result);
         }
 
+        /// ロールメンション文字列が正しく除去されるかテストします。
         #[test]
         fn test_remove_role_string() {
             let str = "aaa<@&8379454856049>eeee";
             let result = convert_discord_string(str);
             assert_eq!("aaaeeee", result);
         }
+        /// 複数のロールメンション文字列が正しく除去されるかテストします。
         #[test]
         fn test_remove_double_role_string() {
             let str = "aaa<@&8379454856049>eeee<@&8379454856049>uuu";
@@ -185,6 +189,7 @@ mod tests {
             assert_eq!("aaaeeeeuuu", result);
         }
 
+        /// 絵文字文字列が絵文字名に正しく置換されるかテストします。
         #[test]
         fn test_remove_emoji_string() {
             let str = "<:butter:872873394570424340>";
@@ -192,6 +197,7 @@ mod tests {
             assert_eq!("butter", result);
         }
 
+        /// アニメーション絵文字文字列が絵文字名に正しく置換されるかテストします。
         #[test]
         fn test_remove_animoji_string() {
             let str = "<a:sanma:872873394570424340>";
@@ -199,6 +205,7 @@ mod tests {
             assert_eq!("sanma", result);
         }
 
+        /// 複数の絵文字文字列が絵文字名に正しく置換されるかテストします。
         #[test]
         fn test_remove_double_emoji_string() {
             let content = "<:butter:872873394570424340>さんま<:sanma:872873394570424340>";
@@ -206,12 +213,14 @@ mod tests {
             assert_eq!("butterさんまsanma", result);
         }
 
+        /// チャンネルリンク文字列が正しく除去されるかテストします。
         #[test]
         fn test_replace_channel_string() {
             let str = "aaa<#795680552845443113>rrr";
             let result = convert_discord_string(str);
             assert_eq!("aaarrr", result);
         }
+        /// 複数のチャンネルリンク文字列が正しく除去されるかテストします。
         #[test]
         fn test_replace_double_channel_string() {
             let str = "aaa<#795680552845443113>rrr<#795680552845443113>sss";
@@ -219,6 +228,7 @@ mod tests {
             assert_eq!("aaarrrsss", result);
         }
 
+        /// スポイラー文字列が正しく除去されるかテストします。
         #[test]
         fn test_spoiler_string() {
             let str = "これは||ネタバレ内容||です";
@@ -226,6 +236,7 @@ mod tests {
             assert_eq!("これはです", result);
         }
 
+        /// 複数のスポイラー文字列が正しく除去されるかテストします。
         #[test]
         fn test_multiple_spoiler_string() {
             let str = "これは||ネタバレ1||と||ネタバレ2||です";
@@ -233,6 +244,7 @@ mod tests {
             assert_eq!("これはとです", result);
         }
 
+        /// スポイラー内にURLとテキストが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_with_url_and_text() {
             let str = "これは||ネタバレ内容 https://example.com||です";
@@ -240,6 +252,7 @@ mod tests {
             assert_eq!("これはです", result);
         }
 
+        /// スポイラー内にURLのみが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_with_url_only() {
             let str = "これは||https://example.com||です";
@@ -247,14 +260,15 @@ mod tests {
             assert_eq!("これはです", result);
         }
 
+        /// スポイラー内に改行とURLが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_with_url_only_with_new_line() {
-            let str = "||改行の次にURLが含まれてる場合、URL以外の部分を読み上げてしまうあわあわあわあわあわあわあわあわあわあわあわあわ。
-https://x.com/tktcorporation/status/1925197887820140825||";
+            let str = "||改行の次にURLが含まれてる場合、URL以外の部分を読み上げてしまうあわあわあわあわあわあわあわあわあわあわあわあわ。\nhttps://x.com/tktcorporation/status/1925197887820140825||";
             let result = convert_discord_string(str);
             assert_eq!("", result);
         }
 
+        /// スポイラー内にテキストとURLが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_with_text_and_url() {
             let str = "これは||ネタバレ内容 https://example.com||です";
@@ -262,6 +276,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             assert_eq!("これはです", result);
         }
 
+        /// メッセージ先頭のスポイラー内にURLとテキストが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_at_beginning_with_url_and_text() {
             let str = "||https://example.com ネタバレ内容||です";
@@ -269,6 +284,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             assert_eq!("です", result);
         }
 
+        /// メッセージ末尾のスポイラー内にURLとテキストが含まれる場合に正しく除去されるかテストします。
         #[test]
         fn test_spoiler_at_end_with_url_and_text() {
             let str = "これは||https://example.com ネタバレ内容||";
@@ -280,6 +296,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
     #[cfg(test)]
     mod to_speech_message_tests {
         use super::*;
+        /// URLのみのメッセージが空文字列に変換されるかテストします。
         #[test]
         fn test_message() {
             let message = message_factory("https://example.com");
@@ -293,6 +310,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// http形式のURLのみのメッセージが空文字列に変換されるかテストします。
         #[test]
         fn test_not_ssl() {
             let message = message_factory("http://example.com");
@@ -306,6 +324,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// テキスト中のURLが正しく除去されるかテストします。
         #[test]
         fn test_url_in_text() {
             let message = message_factory("おはよう https://example.com こんにちは");
@@ -319,6 +338,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// 様々なDiscord特有文字列が混在する場合に正しく変換されるかテストします。
         #[test]
         fn test_mix() {
             let message = message_factory("<@8379454856049>おはよう<:sanma:872873394570424340>こんにちは<#795680552845443113>でも<@&8379454856049>これは<@&8379454856049><:butter:872873394570424340>です");
@@ -332,6 +352,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// 50文字を超えるメッセージが正しくトリミングされ、「うぬんかんぬん」が付加されるかテストします。
         #[test]
         fn test_trimmed_message() {
             let long_text = "あ".repeat(100);
@@ -346,6 +367,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// スポイラー内にURLと50文字を超える長い文字列が含まれる場合、スポイラー全体が除去され空文字列になることをテストします。
         #[test]
         fn test_spoiler_with_url_and_long_text_exceeding_limit() {
             let long_spoiler_text = "あ".repeat(60);
@@ -362,6 +384,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// スポイラー除去後にメッセージ全体が50文字を超える場合、正しくトリミングされるかテストします。
         #[test]
         fn test_message_with_spoiler_exceeding_limit_after_spoiler_removal() {
             let text_around_spoiler = "あ".repeat(60);
@@ -404,6 +427,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// メッセージ中間のスポイラーが除去され、残りのテキストが50文字以内である場合に正しく結合されるかテストします。
         #[test]
         fn test_spoiler_in_middle_within_limit_after_removal() {
             let message_content = "メッセージの始まり||これは秘密です||メッセージの終わり";
@@ -419,6 +443,7 @@ https://x.com/tktcorporation/status/1925197887820140825||";
             );
         }
 
+        /// スポイラー内にURLとテキストが含まれ、スポイラー除去後のメッセージが50文字を超える場合に正しくトリミングされるかテストします。
         #[test]
         fn test_spoiler_containing_url_and_text_then_trimmed() {
             let very_long_text_after_spoiler = "あ".repeat(60);

--- a/src/infrastructure/speech_file_path.rs
+++ b/src/infrastructure/speech_file_path.rs
@@ -2,34 +2,64 @@ use super::SoundPath;
 use std::path::Path;
 use tokio::fs::File;
 
+/// SpeechFileを表す構造体
 #[derive(Debug)]
 pub struct SpeechFile {
+    /// ファイル名
     pub name: String,
+    /// ファイルの実体
     pub value: File,
 }
 
 impl From<SpeechFile> for File {
+    /// SpeechFile から File への変換
+    ///
+    /// # Arguments
+    ///
+    /// * `item` - 変換元のSpeechFile
+    ///
+    /// # Returns
+    ///
+    /// 変換後のFile
     fn from(item: SpeechFile) -> File {
         item.value
     }
 }
 
+/// SpeechFilePathを表す構造体
 #[derive(Debug)]
 pub struct SpeechFilePath {
+    /// ファイルパス
     value: std::path::PathBuf,
 }
 
 impl SpeechFilePath {
+    /// 新しい SpeechFilePath を作成します。
+    ///
+    /// guild ごとに最大5ファイル持つように、ランダムな数値をパスに含めます。
+    ///
+    /// # Arguments
+    ///
+    /// * `sound_path` - SoundPath
+    ///
+    /// # Returns
+    ///
+    /// 新しい SpeechFilePath
     pub fn new(sound_path: SoundPath) -> SpeechFilePath {
         use rand::Rng;
 
         // guild ごとに最大5ファイル持つ
-        let rand_num: i32 = rand::thread_rng().gen_range(0..4);
+        let rand_num: i32 = rand::rng().random_range(0..4);
         std::path::PathBuf::from(sound_path)
             .join(rand_num.to_string())
             .into()
     }
 
+    /// SpeechFile を非同期に取得します。
+    ///
+    /// # Returns
+    ///
+    /// SpeechFile
     pub async fn file(&self) -> SpeechFile {
         let file_name = self.file_name();
 
@@ -39,6 +69,13 @@ impl SpeechFilePath {
         }
     }
 
+    /// ファイル名を取得します。
+    ///
+    /// 拡張子を .mp3 に変更します。
+    ///
+    /// # Returns
+    ///
+    /// ファイル名
     pub fn file_name(&self) -> String {
         let parts: Vec<&str> = self.value.to_str().unwrap().split('.').collect();
         let mut file_name_builder = String::from(parts[0]);
@@ -48,12 +85,30 @@ impl SpeechFilePath {
 }
 
 impl From<std::path::PathBuf> for SpeechFilePath {
+    /// std::path::PathBuf から SpeechFilePath への変換
+    ///
+    /// # Arguments
+    ///
+    /// * `item` - 変換元のstd::path::PathBuf
+    ///
+    /// # Returns
+    ///
+    /// 変換後のSpeechFilePath
     fn from(item: std::path::PathBuf) -> SpeechFilePath {
         SpeechFilePath { value: item }
     }
 }
 
 impl From<SpeechFilePath> for std::path::PathBuf {
+    /// SpeechFilePath から std::path::PathBuf への変換
+    ///
+    /// # Arguments
+    ///
+    /// * `item` - 変換元のSpeechFilePath
+    ///
+    /// # Returns
+    ///
+    /// 変換後のstd::path::PathBuf
     fn from(item: SpeechFilePath) -> std::path::PathBuf {
         item.value
     }


### PR DESCRIPTION
- **:bookmark: v2.4.2**
- **fix: 文字数が長い場合でもspoilerが適切に処理されるように修正**
- **test: Discord特有の文字列処理に関するテストケースを追加し、メンション、絵文字、スポイラーの除去および変換が正しく行われることを確認**
- **refactor: rand::thread_rng().gen_range -> rand::rng().random_range**
